### PR TITLE
Showing all columns for massive upload errors

### DIFF
--- a/src/pages/Loads/ErrorModal/ErrorModal.tsx
+++ b/src/pages/Loads/ErrorModal/ErrorModal.tsx
@@ -25,7 +25,7 @@ const ErrorModal: React.FC<ErrorModalProps> = ({
 	return (
 		<Dialog
 			fullWidth
-			maxWidth='md'
+			maxWidth='xl'
 			open={show}
 			onClose={onClose}
 			aria-labelledby='alert-dialog-title'
@@ -39,6 +39,9 @@ const ErrorModal: React.FC<ErrorModalProps> = ({
 							<TableRow key={i}>
 								<TableCell align='center'>{item.rowIndex}</TableCell>
 								<TableCell>{item.errorMessage}</TableCell>
+								<TableCell>{item.fileName}</TableCell>
+								<TableCell>{item.lineContent}</TableCell>
+								<TableCell>{item.createdAt}</TableCell>
 							</TableRow>
 						))}
 					</React.Fragment>

--- a/src/pages/Loads/columns.ts
+++ b/src/pages/Loads/columns.ts
@@ -16,6 +16,9 @@ export const LOAD_COLUMNS = [
 ];
 
 export const ERROR_COLUMNS = [
-	{ title: 'Línea', props: { align: COLUMN_CENTER } },
+	{ title: 'Fila', props: { align: COLUMN_CENTER } },
 	{ title: 'Error' },
+	{ title: 'Archivo' },
+	{ title: 'Línea' },
+	{ title: 'Fecha' },
 ];


### PR DESCRIPTION
Se colocaron todas las columnas devueltas por el request de verificar errores en la carga masiva
![image](https://user-images.githubusercontent.com/17936716/98782115-6c73f400-23c5-11eb-94bb-3dc0435e93db.png)
